### PR TITLE
Added a space around the <use> tag

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5544,7 +5544,7 @@ function wp_icon( $icon, $attrs = array() ) {
 
 	$sprite_url = '/wp-includes/icons/dashicons.svg';
 	return sprintf(
-		'<svg class="dashicon" %1$s>%2$s<use xlink:href="%3$s" /></svg>',
+		'<svg class="dashicon" %1$s>%2$s <use xlink:href="%3$s" /> </svg>',
 		$attrs['title'] ? '' : 'aria-hidden="true"',
 		$attrs['title'] ? '<title>' . $attrs['title'] . '</title>' : '',
 		esc_url( $sprite_url . '#' . $icon )


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/38387 offers this as a method to
fix a bug in Safari 10